### PR TITLE
Fix path separator for cross-platform compatibility

### DIFF
--- a/sprocketship/utils.py
+++ b/sprocketship/utils.py
@@ -18,7 +18,10 @@ def extract_configs(data, path=""):
 
 def get_file_config(path: Path, config: dict, dir: str):
     filename = path.stem
-    keys = ["procedures"] + str(path.relative_to(dir)).split("/")[:-1] + [filename]
+    relative_path = path.relative_to(dir)
+    # Use Path.parts for cross-platform compatibility
+    path_parts = list(relative_path.parts[:-1])  # Exclude filename from parts
+    keys = ["procedures"] + path_parts + [filename]
 
     file_config = {"path": str(path), "name": filename}
     curr_config = config


### PR DESCRIPTION
## Summary
Fixes hardcoded forward slash in path splitting that breaks on Windows.

## Changes
- Modified `get_file_config()` in `sprocketship/utils.py` to use `pathlib.Path.parts` instead of string splitting with `/`
- This ensures the code works correctly on Windows where paths use `\` separator

## Testing
- Verified diff shows correct changes
- Should be tested on Windows to confirm functionality
- Maintains backward compatibility on macOS/Linux

Fixes issue #3 from codebase analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)