### PR TITLE
Fix grant_usage for procedures without arguments

### DIFF
--- a/sprocketship/utils.py
+++ b/sprocketship/utils.py
@@ -147,8 +147,12 @@ def grant_usage(proc: dict[str, Any], con: SnowflakeConnection) -> None:
         proc: Procedure dictionary containing 'grant_usage', 'database', 'schema', 'name', 'args'
         con: Snowflake connection object
     """
-    types = [arg["type"] for arg in proc["args"]]
-    types_str = f"({','.join(types)})"
+    # Handle procedures without arguments
+    if "args" not in proc or proc["args"] is None:
+        types_str = "()"
+    else:
+        types = [arg["type"] for arg in proc["args"]]
+        types_str = f"({','.join(types)})" if types else "()"
 
     database = quote_identifier(proc['database'])
     schema = quote_identifier(proc['schema'])


### PR DESCRIPTION
## Summary
Fixes crash in `grant_usage()` when procedures have no arguments.

## Problem
The `grant_usage()` function assumed `proc["args"]` always exists and is a list, causing:
- `KeyError: 'args'` when the key is missing
- `TypeError` when `args` is `None`

This is a valid use case - procedures can legitimately have no arguments.

## Changes
- Added defensive check for missing or null `args` in `grant_usage()` function
- Uses empty parentheses `()` for procedures without arguments
- Also handles empty list case: `args: []`

## Testing
- Create a procedure without arguments (no `args:` in frontmatter)
- Add `grant_usage` configuration
- Run `sprocketship liftoff` and verify:
  - No crash occurs
  - GRANT statement executes successfully: `GRANT USAGE ON PROCEDURE db.schema.proc() TO ...`

Fixes issue #1 from codebase analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)