### PR TITLE
Add --version and -v flags to CLI

### DIFF
--- a/sprocketship/cli.py
+++ b/sprocketship/cli.py
@@ -13,6 +13,7 @@ from snowflake import connector  # type: ignore[import-untyped]
 from absql import render_file  # type: ignore[import-untyped]
 from pathlib import Path
 
+from . import __version__
 from .utils import (
     ConfigurationError,
     create_javascript_stored_procedure,
@@ -140,6 +141,7 @@ def _process_procedures(
 
 
 @click.group()
+@click.version_option(__version__, "--version", "-v", prog_name="sprocketship")
 def main() -> None:
     """Main entry point for the sprocketship CLI."""
     pass


### PR DESCRIPTION
## Summary
- Adds `--version` and `-v` command-line flags to display the sprocketship version
- Imports `__version__` from package `__init__.py`
- Uses Click's `@click.version_option()` decorator for standard version display

## Changes
- `sprocketship/cli.py`: Import `__version__` and add version option decorator to main CLI group

## Test plan
- [x] Test `sprocketship --version` displays version correctly
- [x] Test `sprocketship -v` displays version correctly  
- [x] Verify flags appear in `sprocketship --help` output
- [x] Confirm version matches `__version__` in `__init__.py` (1.1.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)